### PR TITLE
Add activationEvent to delay atom-hex loading until its actually used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   "dependencies": {
     "fs-plus": "2.x",
     "entities": "^1.0.0"
-  }
+  },
+  "activationEvents": ["hex:view"]
 }


### PR DESCRIPTION
Without this change, timecop flags this plugin as being one of the slowest to start up on my setup.  With this the startup time drops significantly.
