### PR TITLE
Add a keystroke to activate the hex viewer.

### DIFF
--- a/keymaps/hex.cson
+++ b/keymaps/hex.cson
@@ -1,0 +1,2 @@
+'.editor':
+  'shift-ctrl-h': 'hex:view'


### PR DESCRIPTION
Added a default keystoke to activate the hex viewer.  The keystroke I chose was the default used in Visual SlickEdit.
