### PR TITLE
Fix getPath of undefined error

### DIFF
--- a/lib/hex.coffee
+++ b/lib/hex.coffee
@@ -24,7 +24,7 @@ openURI = (uriToOpen) ->
 
 createView = ->
   paneItem = atom.workspace.getActivePaneItem()
-  filePath = paneItem.getPath()
+  filePath = paneItem?.getPath()
   if paneItem and fs.isFileSync(filePath)
     atom.workspace.open "hex://#{filePath}"
   else


### PR DESCRIPTION
Fix warning when open hex view, without an open file.

Fixes #17  
