### PR TITLE
Fix #14 where spaces are not rendered correctly

### DIFF
--- a/lib/hex-view.coffee
+++ b/lib/hex-view.coffee
@@ -78,7 +78,9 @@ class HexView extends ScrollView
       j = 0
       while j < lastBytes
         v = buffer[b]
-        if (v > 31 and v < 127) or v > 159
+        if (v == 32)
+          ascii += "&nbsp;"
+        else if (v > 32 and v < 127) or v > 159
           ascii += entities.encodeHTML(String.fromCharCode(v))
         else
           ascii += "."


### PR DESCRIPTION
The Atom webview discards consecutive spaces. So if there's multiple 0x20 chars only the first of them will be displayed. This is easily fixed by using &nbsp;
